### PR TITLE
Tweak guess marker remover

### DIFF
--- a/src/Classes/Game.js
+++ b/src/Classes/Game.js
@@ -8,7 +8,6 @@ const legacyStoreFacade = require('../utils/legacyStoreFacade');
 /** @typedef {import('../types').LatLng} LatLng */
 /** @typedef {import('../types').Seed} Seed */
 /** @typedef {import('../types').Guess} Guess */
-/** @typedef {import("../Windows/MainWindow")} MainWindow */
 /** @typedef {import('../utils/Settings')} Settings */
 
 /**
@@ -60,12 +59,10 @@ class Game {
 
 	/**
 	 * @param {import('../utils/Database')} db
-	 * @param {MainWindow} win
 	 * @param {Settings} settings
 	 */
-	constructor(db, win, settings) {
+	constructor(db, settings) {
 		this.#db = db;
-		this.win = win;
 		this.#settings = settings;
 		/** @type {LatLng | undefined} */
 		this.lastLocation = store.get("lastLocation", undefined);
@@ -124,7 +121,6 @@ class Game {
 		const newSeed = await this.#getSeed();
 		// If a guess has been comitted, process streamer guess then return scores
 		if (this.#streamerHasGuessed(newSeed)) {
-			this.win.webContents.send("pre-round-results"); // TODO maybe the renderer side can figure this out on its own
 			this.closeGuesses();
 
 			this.seed = newSeed;

--- a/src/GameHandler.js
+++ b/src/GameHandler.js
@@ -50,7 +50,7 @@ class GameHandler {
 		this.#win = win;
 		this.#settingsWindow = settingsWindow;
 		this.#twitch = new TwitchClient(settings.channelName, settings.botUsername, settings.token);
-		this.#game = new Game(db, win, settings);
+		this.#game = new Game(db, settings);
 		this.#initTmi();
 		this.init();
 	}

--- a/src/preload.js
+++ b/src/preload.js
@@ -28,7 +28,7 @@ function init(rendererApi) {
 	rendererApi.drParseNoCar(noCar);
 
 	const markerRemover = document.createElement("style");
-	markerRemover.textContent = ".map-pin { display: none; }";
+	markerRemover.textContent = '[data-qa="result-view-top"] [data-qa="guess-marker"], [data-qa="result-view-top"] [data-qa="correct-location-marker"] { display: none; }';
 
 	const iconsColumn = document.createElement("div");
 	iconsColumn.classList.add("iconsColumn");
@@ -97,6 +97,7 @@ function init(rendererApi) {
 	});
 
 	ipcRenderer.on("game-started", (e, isMultiGuess, restoredGuesses, location) => {
+		document.body.append(markerRemover);
 		currentLocation = location;
 		if (sharedStore.get('isSatellite')) {
 			centerSatelliteViewBtn.style.display = "flex";
@@ -144,10 +145,6 @@ function init(rendererApi) {
 		scoreboard.renderMultiGuess(guesses);
 	});
 
-	ipcRenderer.on("pre-round-results", () => {
-		document.body.append(markerRemover);
-	});
-
 	ipcRenderer.on("show-round-results", (e, round, location, scores) => {
 		scoreboard.setTitle(`ROUND ${round} RESULTS`);
 		scoreboard.displayScores(scores);
@@ -156,7 +153,6 @@ function init(rendererApi) {
 	});
 
 	ipcRenderer.on("show-final-results", (e, totalScores) => {
-		document.body.append(markerRemover);
 		scoreboard.setTitle("HIGHSCORES");
 		scoreboard.showSwitch(false);
 		scoreboard.displayScores(totalScores, true);
@@ -169,7 +165,6 @@ function init(rendererApi) {
 		scoreboard.reset(isMultiGuess);
 		scoreboard.showSwitch(true);
 		setTimeout(() => {
-			markerRemover.remove();
 			rendererApi.clearMarkers();
 		}, 1000);
 

--- a/src/preload.js
+++ b/src/preload.js
@@ -17,6 +17,9 @@ const chatguessrApi = {
 
 contextBridge.exposeInMainWorld('chatguessrApi', chatguessrApi);
 
+const REMOVE_ALL_MARKERS_CSS = '[data-qa="result-view-top"] [data-qa="guess-marker"], [data-qa="result-view-top"] [data-qa="correct-location-marker"] { display: none; }';
+const REMOVE_GUESS_MARKERS_CSS = '[data-qa="result-view-top"] [data-qa="guess-marker"] { display: none; }';
+
 /**
  * @param {import('./types').RendererApi} rendererApi 
  */
@@ -28,7 +31,7 @@ function init(rendererApi) {
 	rendererApi.drParseNoCar(noCar);
 
 	const markerRemover = document.createElement("style");
-	markerRemover.textContent = '[data-qa="result-view-top"] [data-qa="guess-marker"], [data-qa="result-view-top"] [data-qa="correct-location-marker"] { display: none; }';
+	markerRemover.textContent = REMOVE_ALL_MARKERS_CSS;
 
 	const iconsColumn = document.createElement("div");
 	iconsColumn.classList.add("iconsColumn");
@@ -97,7 +100,9 @@ function init(rendererApi) {
 	});
 
 	ipcRenderer.on("game-started", (e, isMultiGuess, restoredGuesses, location) => {
-		document.body.append(markerRemover);
+		markerRemover.textContent = REMOVE_ALL_MARKERS_CSS;
+		document.head.append(markerRemover);
+
 		currentLocation = location;
 		if (sharedStore.get('isSatellite')) {
 			centerSatelliteViewBtn.style.display = "flex";
@@ -153,6 +158,7 @@ function init(rendererApi) {
 	});
 
 	ipcRenderer.on("show-final-results", (e, totalScores) => {
+		markerRemover.textContent = REMOVE_GUESS_MARKERS_CSS;
 		scoreboard.setTitle("HIGHSCORES");
 		scoreboard.showSwitch(false);
 		scoreboard.displayScores(totalScores, true);


### PR DESCRIPTION
Two small enhancements:
- uses CSS to select only markers on the results map, so the style element doesn't have to be removed/reinserted for every round.
  - This allows us to remove the `pre-round-results` event and lets us decouple the Game class from the window (this is also good for writing tests for it in the future).
- uses a separate CSS rule on the post-game results screen so you can still see the locations on the map.