### PR TITLE
Only use the new database for guess and stats storage

### DIFF
--- a/src/GameHandler.js
+++ b/src/GameHandler.js
@@ -277,7 +277,7 @@ class GameHandler {
 		const userId = userstate.badges?.broadcaster === "1" ? "BROADCASTER" : userstate["user-id"];
 
 		if (message === settings.userGetStatsCmd) {
-			const userInfo = legacyStoreFacade.getUserStats(this.#db, userId, userstate.username);
+			const userInfo = this.#db.getUserStats(userId);
 			if (!userInfo) {
 				await this.#twitch.say(`${userstate["display-name"]} you've never guessed yet.`);
 			} else {
@@ -301,7 +301,7 @@ class GameHandler {
 		}
 
 		if (message === "!best") {
-			const { streak, victories, perfects } = legacyStoreFacade.getGlobalStats(this.#db);
+			const { streak, victories, perfects } = this.#db.getGlobalStats();
 			if (!streak && !victories && !perfects) {
 				await this.#twitch.say("No stats available.");
 			} else {
@@ -321,7 +321,7 @@ class GameHandler {
 		}
 
 		if (message.startsWith("!flag")) {
-			const countryReq = message.substr(message.indexOf(" ") + 1);
+			const countryReq = message.slice(message.indexOf(" ") + 1).trim();
 			const { dbUser } = legacyStoreFacade.getOrMigrateUser(this.#db, userId, userstate.username, userstate["display-name"]);
 
 			let newFlag;

--- a/src/utils/legacyStoreFacade.js
+++ b/src/utils/legacyStoreFacade.js
@@ -8,8 +8,7 @@ const store = require('./sharedStore');
 /** @typedef {import('./Database')} Database */
 
 /**
- * 
- * @param {Database} db 
+ * @param {Database} db
  * @param {string} userId
  * @param {string} username
  * @param {string} displayName
@@ -31,91 +30,4 @@ function getOrMigrateUser(db, userId, username, displayName) {
     return { user, dbUser };
 }
 
-/**
- * Get combined top scoring stats from the database and the old JSON store.
- * 
- * TODO(reanna) we don't *properly* combine stats from the DB and from the JSON store.
- * It just picks whichever score is higher, while for perfects and victories, the
- * stats from the JSON store should first be *added* to the DB stats, before we can
- * pick the highest one. This would be doable by migrating the JSON stats into a separate
- * table in the DB that we can query. Stats can only be migrated for active users since
- * we need to know their twitch user ID.
- * 
- * @param {Database} db 
- */
-function getGlobalStats(db) {
-    const stats = db.getGlobalStats();
-    const allUsers = store.get('users');
-
-    // If there is no legacy data, we don't need to account for it
-    if (!allUsers || Object.keys(allUsers).length === 0) {
-        return stats;
-    }
-
-    let streak = undefined;
-    let perfects = undefined;
-    let victories = undefined;
-    for (const user of Object.values(allUsers)) {
-        if (!streak || user.bestStreak > streak.streak) {
-            streak = { id: user.user, username: user.username, streak: user.bestStreak };
-        }
-        if (!perfects || user.perfects > perfects.perfects) {
-            perfects = { id: user.user, username: user.username, perfects: user.perfects };
-        }
-        if (!victories || user.victories > victories.victories) {
-            victories = { id: user.user, username: user.username, victories: user.victories };
-        }
-    }
-
-    if (!streak || stats.streak && stats.streak.streak > streak.streak) {
-        streak = stats.streak;
-    }
-    if (!perfects || stats.perfects && stats.perfects.perfects > perfects.perfects) {
-        perfects = stats.perfects;
-    }
-    if (!victories || stats.victories && stats.victories.victories > victories.victories) {
-        victories = stats.victories;
-    }
-
-    return { streak, perfects, victories };
-}
-
-/**
- * Get combined user stats from the database and the old JSON based store.
- * 
- * @param {Database} db
- * @param {string} userId
- * @param {string} username
- * @returns {ReturnType<import('./Database')['getUserStats']>}
- */
-function getUserStats(db, userId, username) {
-    const userInfo = db.getUserStats(userId);
-    /** @type {import('./sharedStore').LegacyUser} */
-    const legacyUserInfo = store.get(`users.${username}`)
-    if (!userInfo) {
-        return legacyUserInfo;
-    }
-    if (!legacyUserInfo) {
-        return userInfo;
-    }
-
-    let { bestStreak, correctGuesses, nbGuesses, meanScore, victories, perfects } = userInfo;
-    bestStreak = Math.max(bestStreak, legacyUserInfo.bestStreak);
-    correctGuesses += legacyUserInfo.correctGuesses;
-    nbGuesses += legacyUserInfo.nbGuesses;
-    meanScore = (legacyUserInfo.meanScore * legacyUserInfo.nbGuesses + userInfo.meanScore * userInfo.nbGuesses) / nbGuesses;
-    victories += legacyUserInfo.victories;
-    perfects += legacyUserInfo.perfects;
-
-    return {
-        ...userInfo,
-        bestStreak,
-        correctGuesses,
-        nbGuesses,
-        meanScore,
-        victories,
-        perfects,
-    };
-}
-
-module.exports = { getOrMigrateUser, getGlobalStats, getUserStats };
+module.exports = { getOrMigrateUser };

--- a/src/utils/legacyStoreFacade.test.js
+++ b/src/utils/legacyStoreFacade.test.js
@@ -3,7 +3,7 @@
 const Database = require('./Database');
 /** @type {import('./sharedStore') & { setData: (object: any) => void }} */
 const store = (/** @type {any} */ (require('./sharedStore')));
-const { getOrMigrateUser, getGlobalStats, getUserStats } = require('./legacyStoreFacade');
+const { getOrMigrateUser } = require('./legacyStoreFacade');
 
 jest.mock('./sharedStore');
 
@@ -54,52 +54,6 @@ describe('getOrMigrateUser', () => {
             id: '1234567',
             username: 'LibReAnna',
             flag: 'jo',
-        });
-    });
-});
-
-describe('getGlobalStats', () => {
-    beforeEach(() => {
-        db.getOrCreateUser('1234567', 'LibReAnna');
-        db.getOrCreateUser('1234568', 'fran_stan');
-        db.getGlobalStats = () => ({
-            streak: { id: '1234567', username: 'LibReAnna', streak: 10 },
-            victories: { id: '1234568', username: 'fran_stan', victories: 7 },
-            perfects: { id: '1234567', username: 'LibReAnna', perfects: 2 },
-        });
-    });
-
-    it('returns db stats', () => {
-        expect(getGlobalStats(db)).toEqual({
-            streak: { id: '1234567', username: 'LibReAnna', streak: 10 },
-            victories: { id: '1234568', username: 'fran_stan', victories: 7 },
-            perfects: { id: '1234567', username: 'LibReAnna', perfects: 2 },
-        });
-    });
-
-    it('accounts for stats from the json store', () => {
-        store.setData({
-            users: {
-                libreanna: {
-                    user: 'libreanna',
-                    username: 'LibReAnna',
-                    bestStreak: 9,
-                    victories: 4,
-                    perfects: 0,
-                },
-                fran_stan: {
-                    user: 'fran_stan',
-                    username: 'fran_stan',
-                    bestStreak: 11,
-                    victories: 3,
-                    perfects: 1,
-                },
-            },
-        });
-        expect(getGlobalStats(db)).toEqual({
-            streak: { id: 'fran_stan', username: 'fran_stan', streak: 11 },
-            victories: { id: '1234568', username: 'fran_stan', victories: 7 },
-            perfects: { id: '1234567', username: 'LibReAnna', perfects: 2 },
         });
     });
 });


### PR DESCRIPTION
Migrating all the existing statistics from the electron-store
implementation makes it very complicated to calculate the combined
stats. It's probably not worth the future maintenance burden. So for
now, let's not migrate old stats at all, but keep them in the
electron-store in case we have a reason to add a migration in the future.
(it's easier to keep them than to delete them).

Now the only data that is migrated is your `!flag`.