### PR TITLE
add tests for `getCountryCode` and `selectFlag`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  types:
+    name: Types
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 17.x
+      - name: Install dependencies
+        run: npm ci
+      - name: Check types
+        run: npm run typecheck
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 17.x
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test
+  package:
+    name: Package
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+    runs-on: ${{matrix.os}}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 17.x
+      - name: Install dependencies
+        run: npm ci
+      - name: Package
+        run: npm run package

--- a/src/GameHandler.js
+++ b/src/GameHandler.js
@@ -1,17 +1,14 @@
-"use strict";
-
-const { ipcMain } = require("electron");
-const Game = require("./Classes/Game");
-const GameHelper = require("./utils/GameHelper");
-const Settings = require("./utils/Settings");
-const TwitchClient = require("./Classes/tmi");
-const flags = require("./utils/flags");
-const legacyStoreFacade = require("./utils/legacyStoreFacade");
-const store = require("./utils/sharedStore");
-
+import { ipcMain } from "electron";
+import Game from "./Classes/Game";
+import GameHelper from "./utils/GameHelper";
+import Settings from "./utils/Settings";
+import TwitchClient from "./Classes/tmi";
+import flags from "./utils/flags";
+import legacyStoreFacade from "./utils/legacyStoreFacade";
+import store from "./utils/sharedStore";
 import { io } from "socket.io-client";
-const socket = io(process.env.SOCKET_SERVER_URL);
 
+const socket = io(process.env.SOCKET_SERVER_URL);
 const settings = Settings.read();
 
 /** @typedef {import('./types').Guess} Guess */
@@ -441,4 +438,4 @@ class GameHandler {
 	}
 }
 
-module.exports = GameHandler;
+export default GameHandler;

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ const path = require('path');
 const { app, ipcMain, globalShortcut, protocol } = require("electron");
 const { initRenderer } = require('electron-store');
 const { autoUpdater } = require("electron-updater");
-const GameHandler = require("./GameHandler");
+const GameHandler = require("./GameHandler").default;
 const flags = require('./utils/flags');
 const Database = require('./utils/Database');
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -130,7 +130,7 @@ async function hijackMap() {
 
 		/**
 		 * Check if `element` is a Google Maps script tag and resolve the outer Promise if so.
-		 * @param {HTMLElement} element
+		 * @param {Element} element
 		 */
 		function checkMapsScript(element) {
 			if (element.matches(MAPS_SCRIPT_SELECTOR)) {
@@ -151,7 +151,9 @@ async function hijackMap() {
 		const scriptObserver = new MutationObserver((mutations, observer) => {
 			for (const mutation of mutations) {
 				for (const tmp of mutation.addedNodes) {
-					checkMapsScript(tmp);
+					if (tmp.nodeType === Node.ELEMENT_NODE) {
+						checkMapsScript(/** @type {Element} */ (tmp));
+					}
 				}
 			}
 		});

--- a/src/utils/GameHelper.js
+++ b/src/utils/GameHelper.js
@@ -61,16 +61,6 @@ async function getCountryCode(location) {
   const localResults = countryIso.get(location.lat, location.lng);
   const localIso = localResults.length > 0 ? iso3to2(localResults[0]) : undefined;
 
-  // do we even need this fallback?
-  // const url = new URL('https://api.bigdatacloud.net/data/reverse-geocode');
-  // url.searchParams.append('latitude', `${location.lat}`);
-  // url.searchParams.append('longitude', `${location.lng}`);
-  // url.searchParams.append('key', process.env.BDC_KEY);
-
-  // /** @type {import("axios").AxiosResponse<{ countryCode: string }>} */
-  // const res = await axios.get(url.toString());
-  // const remoteIso = res.data.countryCode === '__' ? undefined : res.data.countryCode;
-  
   return localIso ? countryCodes[localIso] : undefined;
 }
 
@@ -125,7 +115,6 @@ function haversineDistance(mk1, mk2) {
 
 /**
  * Returns score based on distance and scale
- * FIXME this modifies the input
  * @param {number} distance
  * @param {number} scale
  * @return {number} score

--- a/src/utils/GameHelper.test.js
+++ b/src/utils/GameHelper.test.js
@@ -2,18 +2,49 @@
 
 const GameHelper = require("./GameHelper");
 
+describe('getCountryCode', () => {
+	// These are not political opinions, but checks to ensure we match whatever decisions
+	// GeoGuessr has made, even when those decisions are bad.
+
+	it('identifies the country', async () => {
+		const korea = { lat: 37.00990352577917, lng: 128.60820945116575 };
+		await expect(GameHelper.getCountryCode(korea)).resolves.toBe('KR');
+		const luxNearBorder = { lat: 50.18241242506854, lng: 6.022353016459996 };
+		await expect(GameHelper.getCountryCode(luxNearBorder)).resolves.toBe('LU');
+		const nearNorthPole = { lat: 87.94532231211203, lng: 102.72437132716654 };
+		await expect(GameHelper.getCountryCode(nearNorthPole)).resolves.toBe(undefined);
+	});
+	it('counts islands near China under TW rule as Taiwan', async () => {
+		const kinmen = { lat: 24.478693881519966, lng: 118.30351505188996 };
+		await expect(GameHelper.getCountryCode(kinmen)).resolves.toBe('TW');
+		const lienchiang = { lat: 26.1640452690357, lng: 119.91813403003158 };
+		await expect(GameHelper.getCountryCode(lienchiang)).resolves.toBe('TW');
+		const dongyin = { lat: 26.37011790575555, lng: 120.48353606410257 };
+		await expect(GameHelper.getCountryCode(dongyin)).resolves.toBe('TW');
+	});
+	it('counts HK/Macao as China', async () => {
+		const hongKong = { lat: 22.424952693214557, lng: 114.12527863797602 };
+		await expect(GameHelper.getCountryCode(hongKong)).resolves.toBe('CN');
+		const macao = { lat: 22.17174108804142, lng: 113.53648510492957 };
+		await expect(GameHelper.getCountryCode(macao)).resolves.toBe('CN');
+	});
+	it('counts Israel/Palestine as the same country', async () => {
+		const il = await GameHelper.getCountryCode({ lat: 32.034961561407215, lng: 34.75764745886409 });
+		const ps = await GameHelper.getCountryCode({ lat: 31.862835854507576, lng: 35.456499397290635 });
+		expect(il).toBe(ps);
+	});
+	it('counts Åland as Finland', async () => {
+		const aland = { lat: 60.41415638472204, lng: 20.309877225436857 };
+		await expect(GameHelper.getCountryCode(aland)).resolves.toBe('FI');
+	});
+});
+
 describe('parseCoordinates', () => {
 	it("Checks if '30.12345, 50.54321' are valid coordinates >> true", () => {
-		expect(
-			GameHelper.parseCoordinates("30.12345, 50.54321")
-		)
-		.toBeTruthy();
+		expect(GameHelper.parseCoordinates("30.12345, 50.54321")).toBeTruthy();
 	});
 	it("Checks if '30.12345,50.54321' are valid coordinates >> true", () => {
-		expect(
-			GameHelper.parseCoordinates("30.12345,50.54321")
-		)
-		.toBeTruthy();
+		expect(GameHelper.parseCoordinates("30.12345,50.54321")).toBeTruthy();
 	});
 	it("Checks if '-30.12345, -50.54321' are valid coordinates >> true", () => {
 		const coord = GameHelper.parseCoordinates("-30.12345, -50.54321")
@@ -22,21 +53,12 @@ describe('parseCoordinates', () => {
 		expect(coord.lng).toBeCloseTo(-50.54321, 4);
 	});
 	it("Checks if '-30.12345,-50.54321' are valid coordinates >> true", () => {
-		expect(
-			GameHelper.parseCoordinates("-30.12345,-50.54321")
-		)
-		.toBeTruthy();
+		expect(GameHelper.parseCoordinates("-30.12345,-50.54321")).toBeTruthy();
 	});
 	it("Checks if '95.12345, 50.54321' are invalid coordinates >> false", () => {
-		expect(
-			GameHelper.parseCoordinates("95.12345, 50.54321")
-		)
-		.toBeFalsy();
+		expect(GameHelper.parseCoordinates("95.12345, 50.54321")).toBeFalsy();
 	});
 	it("Checks if '30.12345, 190.54321' are invalid coordinates >> false", () => {
-		expect(
-			GameHelper.parseCoordinates("30.12345, 190.54321")
-		)
-		.toBeFalsy();
+		expect(GameHelper.parseCoordinates("30.12345, 190.54321")).toBeFalsy();
 	});
 });

--- a/src/utils/countryCodesNames.json
+++ b/src/utils/countryCodesNames.json
@@ -1,6 +1,6 @@
 [
 	{ "code": "ad", "names": "Andorra" },
-	{ "code": "ae", "names": "United Arab Emirates, UAE" },
+	{ "code": "ae", "names": "UAE, United Arab Emirates" },
 	{ "code": "af", "names": "Afghanistan" },
 	{ "code": "ag", "names": "Antigua and Barbuda" },
 	{ "code": "ai", "names": "Anguilla" },
@@ -81,7 +81,7 @@
 	{ "code": "fr", "names": "France" },
 	{ "code": "frcor", "names": "Corsica, Corse" },
 	{ "code": "ga", "names": "Gabon" },
-	{ "code": "gb", "names": "Great Britain, United Kingdom, UK" },
+	{ "code": "gb", "names": "UK, Great Britain, United Kingdom" },
 	{ "code": "gbeng", "names": "England" },
 	{ "code": "gbsct", "names": "Scotland" },
 	{ "code": "gbwls", "names": "Wales" },

--- a/src/utils/flags.test.js
+++ b/src/utils/flags.test.js
@@ -1,19 +1,36 @@
 'use strict';
 
-const { getEmoji } = require('./flags');
+const flags = require('./flags');
 
 describe('getEmoji', () => {
     it("Check emoji for 'AR' >> '🇦🇷'", () => {
-        expect(getEmoji("AR")).toBe("🇦🇷");
+        expect(flags.getEmoji("AR")).toBe("🇦🇷");
     });
     it("Check emoji for 'GBSCT' >> '🇬🇧 🇸 🇨 🇹'", () => {
-        expect(getEmoji("GBSCT")).toBe("🇬🇧 🇸 🇨 🇹");
+        expect(flags.getEmoji("GBSCT")).toBe("🇬🇧 🇸 🇨 🇹");
     });
     it("Check emoji for 'ESCT' >> '🇪🇸 🇨 🇹'", () => {
-        expect(getEmoji("ESCT")).toBe("🇪🇸 🇨 🇹");
+        expect(flags.getEmoji("ESCT")).toBe("🇪🇸 🇨 🇹");
     });
     it("should not crash with empty flags", () => {
-        expect(getEmoji(null)).toBe('');
-        expect(getEmoji('')).toBe('');
+        expect(flags.getEmoji(null)).toBe('');
+        expect(flags.getEmoji('')).toBe('');
     });
+});
+
+describe('selectFlag', () => {
+	it('supports country/region code input', () => {
+		expect(flags.selectFlag('GB')).toBe('gb');
+		expect(flags.selectFlag('uk')).toBe('gb');
+		expect(flags.selectFlag('SK')).toBe('sk');
+		expect(flags.selectFlag('CAqc')).toBe('caqc');
+		expect(flags.selectFlag('mySWK')).toBe('myswk');
+	});
+	it('supports name input', () => {
+		expect(flags.selectFlag('Brunei')).toBe('bn');
+		expect(flags.selectFlag('korea')).toBe('kr');
+		expect(flags.selectFlag('dprk')).toBe('kp');
+		expect(flags.selectFlag('England')).toBe('gbeng');
+		expect(flags.selectFlag('alabama')).toBe('usal');
+	});
 });


### PR DESCRIPTION
`getCountryCode` maps some country codes to each other to match GeoGuessr's streak behaviour, this adds a few tests so we can make sure that it actually does do the same thing.

Also some tests for `selectFlag`, I noticed it wasn't giving the british flag anymore for `!flag uk`. Tweaking the order in the `names` list makes `match-sorter` use the correct flag again.

Since the socket change added an `import` statement in GameHandler.js, parcel treats it as an ES module. I changed the other requires to match so both parcel and typescript are happy with it.

I also added a github actions workflow so tests and typechecks are run on PRs. we dont need to take it super seriously probably but it's nice as an indication.