### PR TITLE
Fix builtin flags

### DIFF
--- a/src/utils/flags.js
+++ b/src/utils/flags.js
@@ -52,7 +52,7 @@ async function findFlagFile(id) {
 		return { path: customFlagPath };
 	} catch {
 		// we naively fall back to the builtin SVGs. electron will return a 404 for us if the file doesn't exist.
-		return { path: path.join(__dirname, `../../assets/flags/${id}.svg`) };
+		return { path: path.join(__dirname, `../../assets/flags/${id.toUpperCase()}.svg`) };
 	}
 }
 


### PR DESCRIPTION
In the built program, paths are case sensitive even on Windows. All our
flags have uppercase file names, so we should uppercase the country
code/flag ID.