### PR TITLE
fix `banned_users` migration

### DIFF
--- a/src/utils/Database.js
+++ b/src/utils/Database.js
@@ -79,15 +79,10 @@ const migrations = [
             FOREIGN KEY(round_id) REFERENCES rounds(id)
         )`);
 
-        const bannedUsersTable = db.prepare(`CREATE TABLE banned_users (
-            username TEXT NOT NULL
-        )`);
-
         usersTable.run();
         gamesTable.run();
         roundsTable.run();
         guessesTable.run();
-        bannedUsersTable.run();
 
         // These are all deriveable … maybe add them later if it is useful
         /*
@@ -166,6 +161,13 @@ const migrations = [
             ) top_scores ON games.id = top_scores.game_id
             WHERE games.state = 'finished'
         `).run();
+    },
+    function createBannedUsers(db) {
+        const bannedUsersTable = db.prepare(`CREATE TABLE banned_users (
+            username TEXT NOT NULL
+        )`);
+
+        bannedUsersTable.run();
     },
 ];
 


### PR DESCRIPTION
When we add or modify database tables, we always need to do it like this: add a new function at the end of the `migrations` array. Modifying functions in the `migrations` array does nothing, because the database tracks which functions were already run, and they are only ever run once. So if you already started Chatguessr once, the `initialSetup` migration will never be called again. This approach lets us do upgrades to the database when we release a new Chatguessr version, we don't have to delete the DB and start over, but we can upgrade the existing one and keep all the data.