### PR TITLE
Fix executable icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
 		"forge": {
 			"packagerConfig": {
 				"asar": true,
-				"ignore": "\\.parcel-cache"
+				"ignore": "\\.parcel-cache",
+				"icon": "build/icon"
 			},
 			"makers": [
 				{


### PR DESCRIPTION
The icon for the `Chatguessr.exe` needs to be configured here. If we
leave out the extension, electron-packager will pick the right one
depending on target platform (for future macos/linux releases).