### PR TITLE
Fix flag matching on name + support custom SVG flags

### DIFF
--- a/src/utils/flags.js
+++ b/src/utils/flags.js
@@ -42,18 +42,34 @@ async function loadCustomFlagMetadata() {
 }
 
 /**
+ * @param {Flag[]} flags
+ */
+function setCustomFlags(flags) {
+	customFlags = flags;
+}
+
+/**
  * @param {string} id
  * @returns {Promise<import('electron').ProtocolResponse>}
  */
 async function findFlagFile(id) {
-	try {
-		const customFlagPath = path.join(customFlagsDir, `${id}.png`);
-		await fs.access(customFlagPath);
-		return { path: customFlagPath };
-	} catch {
-		// we naively fall back to the builtin SVGs. electron will return a 404 for us if the file doesn't exist.
-		return { path: path.join(__dirname, `../../assets/flags/${id.toUpperCase()}.svg`) };
+	const customFlagPaths = [
+		path.join(customFlagsDir, `${id}.png`),
+		path.join(customFlagsDir, `${id}.svg`),
+	];
+
+	for (const customFlagPath of customFlagPaths) {
+		try {
+			await fs.access(customFlagPath);
+			return { path: customFlagPath };
+		} catch {
+			// Flag file doesn't exist. Try the next, or fall back to builtin flags.
+		}
 	}
+
+	// We always return a path to the builtin SVGs because it's easy.
+	// electron will return a 404 for us if the file doesn't exist.
+	return { path: path.join(__dirname, `../../assets/flags/${id.toUpperCase()}.svg`) };
 }
 
 /**
@@ -67,8 +83,8 @@ function selectFlag(input) {
 
 	const matches = matchSorter(availableFlags, input, {
 		keys: [
-			{ threshold: matchSorter.rankings.EQUAL, key: 'code' },
 			'names',
+			{ threshold: matchSorter.rankings.EQUAL, key: 'code' },
 		],
 	});
 
@@ -135,3 +151,4 @@ exports.findFlagFile = findFlagFile;
 exports.selectFlag = selectFlag;
 exports.randomCountryFlag = randomCountryFlag;
 exports.getEmoji = getEmoji;
+exports.TEST_setCustomFlags = setCustomFlags;

--- a/src/utils/flags.test.js
+++ b/src/utils/flags.test.js
@@ -31,5 +31,18 @@ describe('selectFlag', () => {
 		expect(flags.selectFlag('dprk')).toBe('kp');
 		expect(flags.selectFlag('England')).toBe('gbeng');
 		expect(flags.selectFlag('alabama')).toBe('usal');
+		expect(flags.selectFlag('pride')).toBe('lgbt');
+		expect(flags.selectFlag('lgbt')).toBe('lgbt');
+	});
+	it('matches custom names', () => {
+		flags.TEST_setCustomFlags([
+			{ "code": "corgipasta", "names": "corgipasta", "emoji": "😳" },
+			{ "code": "eviecaps", "names": "evie, eviecaps", "emoji": "🏴‍☠️" },
+		]);
+
+		expect(flags.selectFlag('evie')).toBe('eviecaps');
+		expect(flags.selectFlag('ie')).toBe('ie');
+		expect(flags.selectFlag('corgipasta')).toBe('corgipasta');
+		expect(flags.selectFlag('pasta')).toBe('corgipasta');
 	});
 });


### PR DESCRIPTION
Flipping the key order in the `matchSorter` argument makes it work
correctly … I'm not sure why to be honest but I tested it quite
extensively now so it should be good.

Now custom flags can be either PNG or SVG files.