### PR TITLE
Save streaks in multiguess mode

### DIFF
--- a/src/Classes/Game.js
+++ b/src/Classes/Game.js
@@ -181,8 +181,13 @@ class Game {
 		const guesses = this.#db.getRoundScores(this.#roundId);
 		await pMap(guesses, async (guess) => {
 			const guessedCountry = await GameHelper.getCountryCode(guess.position);
-			const streak = guessedCountry === this.#country ? guess.streak + 1 : 0;
-			this.#db.setGuessCountry(guess.id, guessedCountry, streak);
+			const correct = guessedCountry === this.#country
+			this.#db.setGuessCountry(guess.id, guessedCountry, correct ? guess.streak + 1 : 0);
+			if (guessedCountry === this.#country) {
+				this.#db.addUserStreak(guess.userId, this.#roundId);
+			} else {
+				this.#db.resetUserStreak(guess.userId);
+			}
 		}, { concurrency: 10 });
 	}
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -11,7 +11,6 @@ export type Guess = {
 	streak: number;
 	distance: number;
 	score: number;
-	modified: boolean;
 };
 
 export type Bounds = {

--- a/src/utils/Database.js
+++ b/src/utils/Database.js
@@ -482,6 +482,7 @@ class Database {
         const stmt = this.#db.prepare(`
             SELECT
               guesses.id,
+              guesses.user_id,
               users.username,
               guesses.color,
               guesses.flag,
@@ -494,15 +495,21 @@ class Database {
             ORDER BY distance ASC
         `)
 
-        /** @type {{ id: string, username: string, color: string, flag: string, location: string, streak: number, distance: number, score: number }[]} */
+        /** @type {{ id: string, user_id: string, username: string, color: string, flag: string, location: string, streak: number, distance: number, score: number }[]} */
         const records = stmt.all(roundId);
 
         return records.map((record) => ({
-            ...record,
+            id: record.id,
+            userId: record.user_id,
+            username: record.username,
             user: record.username,
+            color: record.color,
+            flag: record.flag,
+            streak: record.streak,
+            distance: record.distance,
+            score: record.score,
             /** @type {LatLng} */
             position: JSON.parse(record.location),
-            modified: false,
         }));
     }
 


### PR DESCRIPTION
Multiguess mode only resolves country codes for guesses at the very end, but it didn't update user streaks accordingly, only the guess streak. (Streaks are stored in both the `guesses` table and the `streaks` table to make calculating stats easier.)