### PR TITLE
special-case some wrong streak counts

### DIFF
--- a/src/utils/GameHelper.js
+++ b/src/utils/GameHelper.js
@@ -64,10 +64,31 @@ async function fetchSeed(url) {
  * @return {Promise<string | undefined>} Country code or `undefined` if the location is not in a known country.
  */
 async function getCountryCode(location) {
-	const localResults = countryIso.get(location.lat, location.lng);
-	const localIso = localResults.length > 0 ? iso3to2(localResults[0]) : undefined;
+	const localResults = countryIso.get(location.lat, location.lng).map(iso3to2);
+	const localIso = localResults.length > 0 ? localResults[0] : undefined;
+	if (!localIso) {
+		return;
+	}
 
-	return localIso ? countryCodes[localIso] : undefined;
+	let mappedIso = countryCodes[localIso];
+	// `countryIso` does not seem to handle holes in the border polygons correctly,
+	// so we need to patch up some special cases.
+	// This is a short-term patch, we cannot handle anomalies like Baarle this way,
+	// we probably need to find a different library for that.
+	if (localResults.includes("LS") && localResults.includes("ZA")) {
+		mappedIso = "LS"; // Lesotho…
+	}
+	if (localResults.includes("SM") && localResults.includes("IT")) {
+		mappedIso = "SM"; // San Marino
+	}
+	if (localResults.includes("VA") && localResults.includes("IT")) {
+		mappedIso = "VA"; // Vatican City
+	}
+	if (localResults.includes("CH") && localResults.includes("IT")) {
+		mappedIso = "IT"; // Campione d'Italia
+	}
+
+	return mappedIso;
 }
 
 /**

--- a/src/utils/GameHelper.test.js
+++ b/src/utils/GameHelper.test.js
@@ -37,6 +37,22 @@ describe('getCountryCode', () => {
 		const aland = { lat: 60.41415638472204, lng: 20.309877225436857 };
 		await expect(GameHelper.getCountryCode(aland)).resolves.toBe('FI');
 	});
+	it('counts Lesotho as Lesotho', async () => {
+		const ls = { lat: -29.496987596535757, lng: 28.212890625 };
+		expect(await GameHelper.getCountryCode(ls)).toBe('LS');
+	});
+	it('counts Campione d\'Italia as Italy', async () => {
+		const campione = { lat: 45.9689301700563, lng: 8.973770141601562 };
+		expect(await GameHelper.getCountryCode(campione)).toBe('IT');
+	});
+	it('counts San Marino', async () => {
+		const sanMarino = { lat: 43.937461690316646, lng: 12.47222900390625 };
+		expect(await GameHelper.getCountryCode(sanMarino)).toBe('SM');
+	});
+	it('counts Vatican City', async () => {
+		const vatican = { lat: 41.903363034132724, lng: 12.452659606933594 };
+		expect(await GameHelper.getCountryCode(vatican)).toBe('VA');
+	});
 });
 
 describe('parseCoordinates', () => {


### PR DESCRIPTION
country-iso has very granular borders, but it doesn't seem to account
for holey polygons correctly, so countries enclosed by other countries
and enclaves get wrong results. This patch is a simple workaround around
the common cases where this happens. We just check some cases where we
get two results and pick one. In more complicated enclave/exclave
situations like in Baarle this is not possible to do. For a proper fix
we need to fix the library or use a different one that accounts for holes.
I don't have time for that so this will have to do for now.