### PR TITLE
Remove old `botUsername` setting

### DIFF
--- a/src/GameHandler.js
+++ b/src/GameHandler.js
@@ -390,7 +390,7 @@ class GameHandler {
 		}
 
 		if (message === settings.cgCmd && settings.cgCmd !== "") {
-			await this.#backend.sendMessage(settings.cgMsg.replace('<your cg link>', `https://chatguessr.com/map/${settings.botUsername}`));
+			await this.#backend.sendMessage(settings.cgMsg.replace('<your cg link>', `https://chatguessr.com/map/${this.#backend.botUsername}`));
 			return;
 		}
 
@@ -487,27 +487,29 @@ class GameHandler {
 			this.#socket.disconnect();
 		}
 
+		const botUsername = session.user.user_metadata.name;
+
 		this.#socket = io(SOCKET_SERVER_URL, {
 			transportOptions: {
 				polling: {
 					extraHeaders: {
 						access_token: session.access_token,
 						channelname: settings.channelName,
-						bot: session.user.user_metadata.name,
+						bot: botUsername,
 					},
 				},
 			},
 		});
 
 		this.#socket.on("connect", () => {
-			this.#socket.emit("join", settings.botUsername);
+			this.#socket.emit("join", botUsername);
 			if (this.#settingsWindow) {
 				this.#settingsWindow.webContents.send("socket-connected");
 			}
 			console.log("Connected to socket !");
 		});
 
-		this.#socket.on("disconnect", () => {
+		this.#socket.on("disconnect", (reason) => {
 			if (this.#settingsWindow) {
 				this.#settingsWindow.webContents.send("socket-disconnected");
 			}

--- a/src/utils/Settings.js
+++ b/src/utils/Settings.js
@@ -5,7 +5,6 @@ const store = require("./sharedStore");
 /**
  * @typedef {object} SettingsProps
  * @prop {string} channelName
- * @prop {string} botUsername
  * @prop {string} token
  * @prop {string} cgCmd
  * @prop {string} cgMsg
@@ -19,7 +18,6 @@ class Settings {
 	/** @param {Partial<SettingsProps>} settings */
 	constructor({
 		channelName = "",
-		botUsername = "",
 		token = "",
 		cgCmd = "!cg",
 		cgMsg = "Two ways to play: 1. Login with Twitch, make your guess and press guess (spacebar). 2. Paste the command into chat without editing: <your cg link>",
@@ -29,7 +27,6 @@ class Settings {
 		isMultiGuess = false,
 	} = {}) {
 		this.channelName = channelName;
-		this.botUsername = botUsername;
 		this.token = token;
 		this.cgCmd = cgCmd;
 		this.cgMsg = cgMsg;
@@ -70,7 +67,6 @@ class Settings {
 	toJSON() {
 		return {
 			channelName: this.channelName,
-			botUsername: this.botUsername,
 			token: this.token,
 			cgCmd: this.cgCmd,
 			cgMsg: this.cgMsg,


### PR DESCRIPTION
Properly removing it from the `Settings` type so we take it from the Session and the Backend instead as relevant.