### PR TITLE
Sort total scores by score, then distance

### DIFF
--- a/src/utils/Database.js
+++ b/src/utils/Database.js
@@ -577,7 +577,7 @@ class Database {
               AND guesses.round_id = rounds.id
               AND users.id = guesses.user_id
             GROUP BY guesses.user_id
-            ORDER BY score DESC
+            ORDER BY score DESC, distance ASC
         `);
 		/** @type {{ username: string, color: string, flag: string, streak: number, rounds: number, distance: number, score: number }[]} */
 		const records = stmt.all(gameId);

--- a/src/utils/Database.js
+++ b/src/utils/Database.js
@@ -556,29 +556,29 @@ class Database {
 		// performance is not too bad.
 
 		const stmt = this.#db.prepare(`
-            SELECT
-                users.username,
-                guesses.color,
-                users.flag,
-                (
-                    SELECT streak
-                    FROM guesses ig, rounds ir
-                    WHERE ir.game_id = rounds.game_id
-                      AND ig.round_id = ir.id
-                      AND ig.user_id = users.id
-                    ORDER BY ig.created_at DESC
-                    LIMIT 1
-                ) AS streak,
-                COUNT(guesses.id) AS rounds,
-                SUM(guesses.distance) AS distance,
-                SUM(guesses.score) AS score
-            FROM rounds, guesses, users
-            WHERE rounds.game_id = ?
-              AND guesses.round_id = rounds.id
-              AND users.id = guesses.user_id
-            GROUP BY guesses.user_id
-            ORDER BY score DESC, distance ASC
-        `);
+			SELECT
+				users.username,
+				guesses.color,
+				users.flag,
+				(
+					SELECT streak
+					FROM guesses ig, rounds ir
+					WHERE ir.game_id = rounds.game_id
+					  AND ig.round_id = ir.id
+					  AND ig.user_id = users.id
+					ORDER BY ig.created_at DESC
+					LIMIT 1
+				) AS streak,
+				COUNT(guesses.id) AS rounds,
+				SUM(guesses.distance) AS distance,
+				SUM(guesses.score) AS score
+			FROM rounds, guesses, users
+			WHERE rounds.game_id = ?
+			  AND guesses.round_id = rounds.id
+			  AND users.id = guesses.user_id
+			GROUP BY guesses.user_id
+			ORDER BY score DESC, distance ASC
+		`);
 		/** @type {{ username: string, color: string, flag: string, streak: number, rounds: number, distance: number, score: number }[]} */
 		const records = stmt.all(gameId);
 


### PR DESCRIPTION
The total distance and score in a 5-round game aren't directly related, as the drop-off in each individual round is exponential. So normally it is expected that someone can have a *better* score with a *worse* total distance than someone else at the end of a game. But if the scores are identical, it looks a bit strange if the one with the better distance places worse in the final ranking. So now if there's an identical score, the distance is used as a tie-breaker.