### PR TITLE
Fix sorting 5Ks by guess time in multi-guess mode

### DIFF
--- a/src/utils/Database.js
+++ b/src/utils/Database.js
@@ -353,7 +353,14 @@ class Database {
 	updateGuess(guessId, guess) {
 		const updateGuess = this.#db.prepare(`
             UPDATE guesses
-            SET color = :color, flag = :flag, location = :location, country = :country, streak = :streak, distance = :distance, score = :score
+            SET color = :color,
+                flag = :flag,
+                location = :location,
+                country = :country,
+                streak = :streak,
+                distance = :distance,
+                score = :score,
+					 created_at = :updatedAt
             WHERE id = :id
         `);
 
@@ -366,8 +373,7 @@ class Database {
 			streak: guess.streak,
 			distance: guess.distance,
 			score: guess.score,
-			// probably not useful but maybe?
-			// updatedAt: timestamp(),
+			updatedAt: timestamp(),
 		});
 	}
 


### PR DESCRIPTION
Previously the time of your initial guess was used, so you could insta-send in the ocean and then adjust when you find the 5K and still get top spot. Now if you change your guess, the final time is the time that's used for sorting.