### PR TITLE
Show broken streak in round score screen only

### DIFF
--- a/src/Classes/Scoreboard.js
+++ b/src/Classes/Scoreboard.js
@@ -251,7 +251,7 @@ class Scoreboard {
 			Player: `${guess.flag ? `<span class="flag-icon" style="background-image: url(flag:${guess.flag})"></span>` : ""}<span class='username' style='color:${
 				guess.color
 			}'>${guess.username}</span>`,
-			Streak: { current: guess.streak, last: guess.lastStreak },
+			Streak: { current: guess.streak, last: null },
 			Distance: { value: guess.distance, display: this.toMeter(guess.distance) },
 			Score: guess.score,
 		};


### PR DESCRIPTION
Most people either play with only showing # and Player, or only # and Player and Streak. In that case, having the `0 [7]` syntax is a bit noisy while people are still guessing. It's more palatable on the round score screen.