### PR TITLE
Add command !map to display the name and description of the current map

### DIFF
--- a/src/GameHandler.js
+++ b/src/GameHandler.js
@@ -427,6 +427,11 @@ class GameHandler {
     #cgCooldown = false;
 
     /**
+     * @type {boolean}
+     */
+    #mapCooldown = false;
+
+    /**
      * @param {import("tmi.js").ChatUserstate} userstate
      * @param {string} message
      */
@@ -482,6 +487,23 @@ class GameHandler {
 
         if (message === settings.flagsCmd) {
             await this.#backend.sendMessage(settings.flagsCmdMsg);
+        }
+
+        if (message === settings.mapCmd) {
+            // We'll only have a map ID if we're 
+            if(!this.#game.isInGame || !this.#game.seed || !this.#game.seed.map) {
+                return;
+            } 
+            if(!this.#mapCooldown) {
+                this.#mapCooldown = true; 
+
+                const map = await GameHelper.fetchMap(this.#game.seed.map);
+                await this.#backend.sendMessage(`🌎 Now playing '${map.name}' by ${map.creator.nick}, played ${map.numFinishedGames} times with ${map.likes} likes: ${map.description}` );
+                
+                setTimeout(() => {
+                    this.#mapCooldown = false;
+                }, settings.mapCmdCooldown * 1000);
+            }
         }
 
         if (message === settings.getUserStatsCmd) {

--- a/src/GameHandler.js
+++ b/src/GameHandler.js
@@ -494,16 +494,19 @@ class GameHandler {
             if(!this.#game.isInGame || !this.#game.seed || !this.#game.seed.map) {
                 return;
             } 
-            if(!this.#mapCooldown) {
-                this.#mapCooldown = true; 
 
-                const map = await GameHelper.fetchMap(this.#game.seed.map);
-                await this.#backend.sendMessage(`🌎 Now playing '${map.name}' by ${map.creator.nick}, played ${map.numFinishedGames} times with ${map.likes} likes: ${map.description}` );
-                
-                setTimeout(() => {
-                    this.#mapCooldown = false;
-                }, settings.mapCmdCooldown * 1000);
-            }
+			// Allow the broadcaster to circumvent the cooldown
+            if(this.#mapCooldown && userId !== "BROADCASTER") {
+				return;
+			}
+			this.#mapCooldown = true; 
+
+			const map = await GameHelper.fetchMap(this.#game.seed.map);
+			await this.#backend.sendMessage(`🌎 Now playing '${map.name}' by ${map.creator.nick}, played ${map.numFinishedGames} times with ${map.likes} likes: ${map.description}` );
+			
+			setTimeout(() => {
+				this.#mapCooldown = false;
+			}, settings.mapCmdCooldown * 1000);
         }
 
         if (message === settings.getUserStatsCmd) {

--- a/src/Windows/settings/settings.html
+++ b/src/Windows/settings/settings.html
@@ -125,6 +125,13 @@
                                 <input class="form__field" type="text" id="clearUserStatsCmd" spellcheck="false" />
                             </div>
                         </div>
+
+                        <div class="form__group">
+                            <label class="form__label">Describe current map :</label>
+                            <div data-tip="Display information about the current map in chat (default: !map)">
+                                <input class="form__field" type="text" id="mapCmd" spellcheck="false" />
+                            </div>
+                        </div>
                     </div>
 
                     <div class="col">
@@ -146,6 +153,13 @@
                             <label class="form__label">Random plonk :</label>
                             <div data-tip="Guess random coordinates (default: !randomplonk)">
                                 <input class="form__field" type="text" id="randomPlonkCmd" spellcheck="false" />
+                            </div>
+                        </div>
+
+                        <div class="form__group">
+                            <label class="form__label">Describe map cooldown (in sec) :</label>
+                            <div data-tip="Map description cooldown (default: 30)">
+                                <input class="form__field" type="number" min="0" max="1000" id="mapCmdCooldown" />
                             </div>
                         </div>
                     </div>

--- a/src/Windows/settings/settings.js
+++ b/src/Windows/settings/settings.js
@@ -33,6 +33,10 @@ const clearUserStatsCmd = qs("#clearUserStatsCmd");
 /** @type {HTMLInputElement} */
 const randomPlonkCmd = qs("#randomPlonkCmd");
 /** @type {HTMLInputElement} */
+const mapCmd = qs("#mapCmd");
+/** @type {HTMLInputElement} */
+const mapCmdCooldown = qs("#mapCmdCooldown");
+/** @type {HTMLInputElement} */
 const showHasGuessed = qs("#showHasGuessed");
 /** @type {HTMLInputElement} */
 const showHasAlreadyGuessed = qs("#showHasAlreadyGuessed");
@@ -75,6 +79,8 @@ ipcRenderer.on("render-settings", (_event, settings, bannedUsers, connectionStat
     getUserStatsCmd.value = settings.getUserStatsCmd;
     getBestStatsCmd.value = settings.getBestStatsCmd;
     clearUserStatsCmd.value = settings.clearUserStatsCmd;
+    mapCmd.value = settings.mapCmd;
+    mapCmdCooldown.value = settings.mapCmdCooldown;
     randomPlonkCmd.value = settings.randomPlonkCmd;
     showHasGuessed.checked = settings.showHasGuessed;
     showHasAlreadyGuessed.checked = settings.showHasAlreadyGuessed;
@@ -191,6 +197,8 @@ function saveGlobalSettings() {
         getUserStatsCmd: getUserStatsCmd.value,
         getBestStatsCmd: getBestStatsCmd.value,
         clearUserStatsCmd: clearUserStatsCmd.value,
+        mapCmd: mapCmd.value,
+        mapCmdCooldown: mapCmd.Cooldownvalue,
         randomPlonkCmd: randomPlonkCmd.value,
         showHasGuessed: showHasGuessed.checked,
         showHasAlreadyGuessed: showHasAlreadyGuessed.checked,

--- a/src/Windows/settings/settings.js
+++ b/src/Windows/settings/settings.js
@@ -198,7 +198,7 @@ function saveGlobalSettings() {
         getBestStatsCmd: getBestStatsCmd.value,
         clearUserStatsCmd: clearUserStatsCmd.value,
         mapCmd: mapCmd.value,
-        mapCmdCooldown: mapCmd.Cooldownvalue,
+        mapCmdCooldown: mapCmdCooldown.value,
         randomPlonkCmd: randomPlonkCmd.value,
         showHasGuessed: showHasGuessed.checked,
         showHasAlreadyGuessed: showHasAlreadyGuessed.checked,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,5 @@
 import { IpcRenderer } from "electron";
+import internal from "stream";
 
 export type LatLng = { lat: number; lng: number };
 export type Location = {
@@ -127,6 +128,30 @@ export type Seed = GameSettings & {
     player: GamePlayer;
     state: GameState;
     type: GameType;
+};
+
+export type GeoguessrUser = {
+    nick: string;
+    created: string;
+    isVerified: boolean;
+    isCreator: boolean;
+    countryCode: string;
+};
+
+export type GeoGuessrMap = {
+    id: string;
+    name: string;
+    slug: string;
+    description: string;
+    url: string;
+    playUrl: string;
+    bounds: Bounds;
+    creator: GeoguessrUser;
+    createdAt: Date;
+    numFinishedGames: number;
+    averageScore: number;
+    maxErrorDistance: number;
+    likes: number;
 };
 
 export interface RendererApi {

--- a/src/utils/GameHelper.js
+++ b/src/utils/GameHelper.js
@@ -18,6 +18,7 @@ const CG_PUBLIC_URL = process.env.CG_PUBLIC_URL ?? "chatguessr.com";
 /** @typedef {import('../types').LatLng} LatLng */
 /** @typedef {import('../types').GameResult} GameResult */
 /** @typedef {import('../types').Seed} Seed */
+/** @typedef {import("../types").GeoGuessrMap} GeoGuessrMap */
 
 /**
  * Checks if the URL is an in-game page.
@@ -69,6 +70,21 @@ async function fetchSeed(url) {
     }
 
     const { data } = await axios.get(`${GEOGUESSR_URL}/api/v3/games/${gameId}`, { headers: cookies });
+    return data;
+}
+
+/**
+ * Fetch the full map info from the current game, if one is active
+ * @param {string} mapToken The base16 map identifier
+ * @return {Promise<GeoGuessrMap | undefined>} Seed Promise
+ */
+async function fetchMap(mapToken) {
+    const cookies = await getCookies();
+    if (!cookies) {
+        return;
+    }
+
+    const { data } = await axios.get(`${GEOGUESSR_URL}/api/maps/${mapToken}`, { headers: cookies });
     return data;
 }
 
@@ -202,6 +218,7 @@ async function getRandomCoordsInLand(bounds = null) {
 }
 
 exports.isGameURL = isGameURL;
+exports.fetchMap = fetchMap;
 exports.fetchSeed = fetchSeed;
 exports.getCountryCode = getCountryCode;
 exports.parseCoordinates = parseCoordinates;

--- a/src/utils/Settings.js
+++ b/src/utils/Settings.js
@@ -14,6 +14,8 @@ const store = require("./sharedStore");
  * @prop {string} getUserStatsCmd
  * @prop {string} getBestStatsCmd
  * @prop {string} clearUserStatsCmd
+ * @prop {string} mapCmd 
+ * @prop {number} mapCmdCooldown
  * @prop {string} randomPlonkCmd
  * @prop {boolean} showHasGuessed
  * @prop {boolean} showHasAlreadyGuessed
@@ -38,6 +40,8 @@ class Settings {
         getUserStatsCmd = "!me",
         getBestStatsCmd = "!best",
         clearUserStatsCmd = "!clear",
+        mapCmd = "!map",
+        mapCmdCooldown = 30,
         randomPlonkCmd = "!randomplonk",
         showHasGuessed = true,
         showHasAlreadyGuessed = true,
@@ -56,6 +60,8 @@ class Settings {
         this.getUserStatsCmd = getUserStatsCmd;
         this.getBestStatsCmd = getBestStatsCmd;
         this.clearUserStatsCmd = clearUserStatsCmd;
+        this.mapCmd = mapCmd;
+        this.mapCmdCooldown = mapCmdCooldown;
         this.randomPlonkCmd = randomPlonkCmd;
         this.showHasGuessed = showHasGuessed;
         this.showHasAlreadyGuessed = showHasAlreadyGuessed;
@@ -75,6 +81,8 @@ class Settings {
      * clearUserStatsCmd: string,
      * getUserStatsCmd: string,
      * getBestStatsCmd: string,
+     * mapCmd: string,
+     * mapCmdCooldown: number,
      * randomPlonkCmd: string,
      * showHasGuessed: boolean,
      * showHasAlreadyGuessed: boolean,
@@ -93,6 +101,8 @@ class Settings {
         this.getUserStatsCmd = globalSettings.getUserStatsCmd;
         this.getBestStatsCmd = globalSettings.getBestStatsCmd;
         this.clearUserStatsCmd = globalSettings.clearUserStatsCmd;
+        this.mapCmd = globalSettings.mapCmd;
+        this.mapCmdCooldown = globalSettings.mapCmdCooldown;
         this.randomPlonkCmd = globalSettings.randomPlonkCmd;
         this.showHasGuessed = globalSettings.showHasGuessed;
         this.showHasAlreadyGuessed = globalSettings.showHasAlreadyGuessed;
@@ -123,6 +133,8 @@ class Settings {
             getUserStatsCmd: this.getUserStatsCmd,
             getBestStatsCmd: this.getBestStatsCmd,
             clearUserStatsCmd: this.clearUserStatsCmd,
+            mapCmd: this.mapCmd,
+            mapCmdCooldown: this.mapCmdCooldown,
             randomPlonkCmd: this.randomPlonkCmd,
             showHasGuessed: this.showHasGuessed,
             showHasAlreadyGuessed: this.showHasAlreadyGuessed,


### PR DESCRIPTION
A map's description is often helpful to understand what types of locations to expect in a game, especially if one is playing a map with unofficial coverage of various sorts. This PR adds a command `!map` that:

* Retrieves the current seed's map from the Geoguessr API
* Displays a message with the title, creator, summary, and the number of plays/likes

(I decided to include the creator/# plays/# likes because that helps indicate if the streamer is playing an imposter map)

I did this as an additional API call because unfortunately the seed information only has the map title, not the map description.

Because that extra API call can be slow, I included a cooldown period.

If you're interested in incorporating this, please feel welcome to suggest any changes or make any edits!