### PR TITLE
Add options to !best and !me to filter by dates

### DIFF
--- a/src/main/utils/gameHelper.test.ts
+++ b/src/main/utils/gameHelper.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest'
 import * as GameHelper from './gameHelper'
 
 describe('getCountryCode', () => {
@@ -116,5 +116,41 @@ describe('randomPlonk', () => {
       expect(lng > inBounds.min.lng).toBeTruthy()
       expect(lng < inBounds.max.lng).toBeTruthy()
     }
+  })
+})
+
+describe('parseUserDate', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('Handles undefined date as epoch=0', async () => {
+      expect(await GameHelper.parseUserDate(undefined)).toEqual({timeStamp: 0})
+  })
+
+  it('Handles empty date as epoch=0', async () => {
+    expect(await GameHelper.parseUserDate("")).toEqual({timeStamp: 0})
+})
+
+  it('Parses "day" correctly', async () => {
+    vi.setSystemTime(new Date("2000-01-17T16:01:23"))
+    const dateInfo = await GameHelper.parseUserDate("day")
+    expect(dateInfo.timeStamp).toEqual(GameHelper.dateToUnixTimestamp(new Date("2000-01-17T00:00:00")))
+  })
+
+  it('Parses "month" correctly', async () => {
+    vi.setSystemTime(new Date("2001-01-17T16:01:23"))
+    const dateInfo = await GameHelper.parseUserDate("month")
+    expect(dateInfo.timeStamp).toEqual(GameHelper.dateToUnixTimestamp(new Date("2001-01-01T00:00:00")))
+  })
+
+  it('Parses "year" correctly', async () => {
+    vi.setSystemTime(new Date("2002-04-17T16:01:23"))
+    const dateInfo = await GameHelper.parseUserDate("year")
+    expect(dateInfo.timeStamp).toEqual(GameHelper.dateToUnixTimestamp(new Date("2002-01-01T00:00:00")))
   })
 })

--- a/src/main/utils/gameHelper.test.ts
+++ b/src/main/utils/gameHelper.test.ts
@@ -142,6 +142,17 @@ describe('parseUserDate', () => {
     expect(dateInfo.timeStamp).toEqual(GameHelper.dateToUnixTimestamp(new Date("2000-01-17T00:00:00")))
   })
 
+  it('Parses "week" correctly', async () => {
+    const monday = "2024-04-15:01:23"
+    vi.setSystemTime(new Date(monday))
+    let dateInfo = await GameHelper.parseUserDate("week")
+    expect(dateInfo.timeStamp).toEqual(GameHelper.dateToUnixTimestamp(new Date("2024-04-15:00:00")))
+    const sunday = "2024-04-21:01:23"
+    vi.setSystemTime(new Date(sunday))
+    dateInfo = await GameHelper.parseUserDate("week")
+    expect(dateInfo.timeStamp).toEqual(GameHelper.dateToUnixTimestamp(new Date("2024-04-15:00:00")))
+  })
+
   it('Parses "month" correctly', async () => {
     vi.setSystemTime(new Date("2001-01-17T16:01:23"))
     const dateInfo = await GameHelper.parseUserDate("month")

--- a/src/main/utils/gameHelper.ts
+++ b/src/main/utils/gameHelper.ts
@@ -235,7 +235,7 @@ export function dateToUnixTimestamp(date: Date): number
  */
 export async function parseUserDate(userDateStr: string | undefined):  Promise<{ timeStamp: number, description: string | undefined}> {
   let timeStamp = -1
-  let description: string | undefined = "Unsupported date (supported dates: 'day', 'month', 'year')."
+  let description: string | undefined = "Unsupported date (supported dates: 'day', 'week', 'month', 'year')."
   if (!userDateStr) {
     timeStamp = 0
     description = undefined
@@ -243,6 +243,12 @@ export async function parseUserDate(userDateStr: string | undefined):  Promise<{
   if (userDateStr === "day" || userDateStr === "today") {
     timeStamp = dateToUnixTimestamp(new Date(new Date().setHours(0,0,0,0)))
     description = "today"
+  } else if(userDateStr === "week") {
+    const lastMidnight = new Date(new Date().setHours(0,0,0,0))
+    var day = lastMidnight.getDay() || 7; // Convert sunday to 7
+    lastMidnight.setHours(-24 * (day - 1)); 
+    timeStamp = dateToUnixTimestamp(lastMidnight)
+    description = "this week"
   } else if(userDateStr === "month") {
     const now = new Date()
     timeStamp = dateToUnixTimestamp(new Date(now.getFullYear(), now.getMonth(), 1))

--- a/src/main/utils/gameHelper.ts
+++ b/src/main/utils/gameHelper.ts
@@ -223,3 +223,34 @@ export async function getStreamerAvatar(channel: string): Promise<{ avatar: stri
     return { avatar: undefined }
   }
 }
+
+export function dateToUnixTimestamp(date: Date): number
+{
+  return Math.floor(date.getTime() / 1000)
+}
+
+/**
+ * Parses a user-defined string that represents a date into a Unix timestamp. Will set timestamp to > 0 on success
+ * or == 0 for an empty input, and -1 on unrecognized dates.
+ */
+export async function parseUserDate(userDateStr: string | undefined):  Promise<{ timeStamp: number, description: string | undefined}> {
+  let timeStamp = -1
+  let description: string | undefined = "Unsupported date (supported dates: 'day', 'month', 'year')."
+  if (!userDateStr) {
+    timeStamp = 0
+    description = undefined
+  }
+  if (userDateStr === "day" || userDateStr === "today") {
+    timeStamp = dateToUnixTimestamp(new Date(new Date().setHours(0,0,0,0)))
+    description = "today"
+  } else if(userDateStr === "month") {
+    const now = new Date()
+    timeStamp = dateToUnixTimestamp(new Date(now.getFullYear(), now.getMonth(), 1))
+    description = "this month"
+  } else if(userDateStr === "year") {
+    const now = new Date()
+    timeStamp = dateToUnixTimestamp(new Date(now.getFullYear(), 0, 1))
+    description = "this year"
+  }
+  return {timeStamp: timeStamp, description: description}
+}


### PR DESCRIPTION
This PR adds the options `day`, `month`, and `year` to the `!best` and `!me` commands in order to get recent statistics. The intent is to be able to track different levels of stats, both on a global scale and for individual users.

If you decide to adopt this, feel free to make any modifications/refactoring as you please!

### Considerations
1. Should it be possible to send in any custom date? Currently I decided to keep it simple by restricting it to only a few defined string values, but in theory, custom dates could be supported. One thing that could be interesting is to add a setting for the streamer to enter a custom date for i.e. weekly/weekend tournaments.
2. Should there be a setting to enable/disable querying by dates for the streamer? 
3. Maybe `week` should be an option, and if so, should start of the week be configurable via settings?

If you think any of these would be a good idea, let me know and I will add them. 