### PR TITLE
Don't allow using !me after guessing during a round

### DIFF
--- a/src/main/GameHandler.ts
+++ b/src/main/GameHandler.ts
@@ -564,6 +564,11 @@ export default class GameHandler {
         await this.#backend?.sendMessage(`${userstate['display-name']}: ${dateInfo.description}.`)
         return
       }
+      const hasGuessedOnOngoingRound = this.#db.userGuessedOnOngoingRound(userId)
+      if (hasGuessedOnOngoingRound) {
+        await this.#backend?.sendMessage(`${userstate['display-name']}: ${settings.getUserStatsCmd} cannot be used after guessing during an ongoing round.`)
+        return
+      }
       const userInfo = this.#db.getUserStats(userId, dateInfo.timeStamp)
       if (!userInfo) {
         if (dateInfo.timeStamp === 0) {

--- a/src/main/utils/Database.test.ts
+++ b/src/main/utils/Database.test.ts
@@ -26,6 +26,52 @@ function createGame() {
   return token
 }
 
+describe('userGuessedOnOngoingRound', () => {
+  it('returnsTrueWhenUserHasGuessed', () => {
+    const broadcaster = db.getOrCreateUser('BROADCASTER', 'BROADCASTER', undefined, undefined)
+    const user = db.getOrCreateUser('1234567', 'libjanosgeo', undefined, undefined)
+    const secondUser = db.getOrCreateUser('2345678', 'secondUser', undefined, undefined)
+
+    const token = createGame()
+    const firstRoundId = db.createRound(token, {
+      lat: 0,
+      lng: 0,
+      panoId: null,
+      heading: 0,
+      pitch: 0,
+      zoom: 0
+    })
+
+    expect(db.userGuessedOnOngoingRound(user!.id)).toEqual(false)
+    expect(db.userGuessedOnOngoingRound(secondUser!.id)).toEqual(false)
+    
+    db.createGuess(firstRoundId, user!.id, {
+      location: { lat: 0, lng: 0 },
+      country: null,
+      streak: 1,
+      lastStreak: null,
+      distance: 0,
+      score: 5000
+    })
+
+    expect(db.userGuessedOnOngoingRound(user!.id)).toEqual(true)
+    expect(db.userGuessedOnOngoingRound(secondUser!.id)).toEqual(false)
+
+    // When broadcaster has guessed, round ends
+    db.createGuess(firstRoundId, broadcaster!.id, {
+      location: { lat: 0, lng: 0 },
+      country: null,
+      streak: 1,
+      lastStreak: null,
+      distance: 0,
+      score: 2500
+    })
+    expect(db.userGuessedOnOngoingRound(user!.id)).toEqual(false)
+    expect(db.userGuessedOnOngoingRound(secondUser!.id)).toEqual(false)
+
+  })
+})
+
 describe('getUserStats', () => {
   it('counts victories', () => {
     const user = db.getOrCreateUser('1234567', 'libreanna', undefined, undefined)


### PR DESCRIPTION
There is an exploit that can be used with the !me-command. After making a guess, !me will include information about the guess
- Current streak will reflect whether user guessed the correct country
- Average score includes the score for the guess
- 5k count includes information about whether the user 5k'd.

If multiguess is turned on, then this information can be used to alter the guess!

This commit fixes this exploit by rejecting the !me-command after guessing during an active round (active being determined whether the 'BROADCASTER' has guessed or not).

Feel free (as always) to make changes as necessary.