### PR TITLE
Add opacity on the flag marker on hover

### DIFF
--- a/src/renderer/assets/override-gg-styles.css
+++ b/src/renderer/assets/override-gg-styles.css
@@ -67,6 +67,10 @@
   position: relative;
   z-index: 999;
 }
+/* change opacity of correct-location-marker on hover */
+[data-qa="correct-location-marker"]:hover {
+  opacity: 0.4;
+}
 
 .gm-style .gm-style-iw-c,
 .gm-style .gm-style-iw-tc::after {


### PR DESCRIPTION
Adopting from vinz's fork since this is a small but neat feature:

It adds a transparency on the flag that displays the correct location on the round result screen. This makes it easier to spot if there are any guesses close to the correct location (currently the streamer has to zoom in or look at the results screen to find that out).