### PR TITLE
Extenssr post processing fixes

### DIFF
--- a/src/renderer/components/Mods/ExtenssrFilters.vue
+++ b/src/renderer/components/Mods/ExtenssrFilters.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { reactive, watch } from 'vue'
 import { getLocalStorage, setLocalStorage } from '../../useLocalStorage'
+import { defaultPP } from '@/mods/extenssr/post_processing_controller'
 
 const settings = reactive(
   getLocalStorage('cg_filters__settings', {
@@ -17,6 +18,27 @@ const settings = reactive(
     min: false
   })
 )
+// Set initial post processing values
+if (window.pp) {
+  const ppKeys = Object.keys(window.pp)
+  for (let key of Object.keys(settings)) {
+    if (ppKeys.includes(key)) {
+      window.pp[key] = settings[key]
+    }
+  }
+  if (window.ppController) {
+    try {
+      window.ppController.updateState(window.pp)
+    }catch(e) {
+      window.pp = defaultPP()
+      for(let key of Object.keys(window.pp)) {
+        settings[key] = window.pp[key]
+      }
+      window.ppController.updateState(window.pp)
+    }
+  }
+}
+
 watch(settings, () => {
   setLocalStorage('cg_filters__settings', settings)
 })

--- a/src/renderer/components/Mods/ExtenssrFilters.vue
+++ b/src/renderer/components/Mods/ExtenssrFilters.vue
@@ -100,7 +100,7 @@ const onToonScaleChange = () => {
 const onPixelScaleChange = () => {
   if (window.ppController) {
     window.pp.pixelScale = settings.pixelScale
-    toggleMode('toon')
+    toggleMode('pixelate')
   }
 }
 </script>

--- a/src/renderer/components/Mods/ExtenssrFilters.vue
+++ b/src/renderer/components/Mods/ExtenssrFilters.vue
@@ -66,40 +66,41 @@ const toggleNoCompassMode = () => {
 const toggleMode = (property: keyof typeof settings) => {
   if (window.ppController) {
     window.pp[property] = settings[property]
-    window.ppController.updateState(window.pp)
+    try {
+      window.ppController.updateState(window.pp)
+    } catch(e) {
+      console.log('Whoops, try to get back to a sane state')
+      window.pp = defaultPP()
+      for (let key of Object.keys(window.pp)) {
+        settings[key] = window.pp[key]
+      }
+      window.ppController.updateState(window.pp)
+      return;
+    }
+    // Fixup after updating the state; some settings are mutually exclusive
+    for (let key of Object.keys(settings)) {
+      if (key !== property && settings[key] !== window.pp[key]) {
+        settings[key] = window.pp[key]
+      }
+    }
   }
 }
 const toggleGrayscaleMode = () => {
   document.body.style.filter = settings.grayscale ? 'grayscale(100%)' : 'none'
 }
 
-const toggleToonMode = () => {
-  if (window.ppController) {
-    window.pp.toon = settings.toon
-    window.pp.toonScale = settings.toonScale
-    window.ppController.updateState(window.pp)
-  }
-}
 
 const onToonScaleChange = () => {
   if (window.ppController) {
     window.pp.toonScale = settings.toonScale
-    window.ppController.updateState(window.pp)
-  }
-}
-
-const togglePixelateMode = () => {
-  if (window.ppController) {
-    window.pp.pixelate = settings.pixelate
-    window.pp.pixelScale = settings.pixelScale
-    window.ppController.updateState(window.pp)
+    toggleMode('toon')
   }
 }
 
 const onPixelScaleChange = () => {
   if (window.ppController) {
     window.pp.pixelScale = settings.pixelScale
-    window.ppController.updateState(window.pp)
+    toggleMode('toon')
   }
 }
 </script>
@@ -139,7 +140,7 @@ const onPixelScaleChange = () => {
             v-model="settings.toon"
             type="checkbox"
             class="toggle_toggle"
-            @change="toggleToonMode()"
+            @change="toggleMode('toon')"
           />
           <label class="game-options_optionLabel">Toon</label>
         </div>
@@ -161,7 +162,7 @@ const onPixelScaleChange = () => {
             v-model="settings.pixelate"
             type="checkbox"
             class="toggle_toggle"
-            @change="togglePixelateMode()"
+            @change="toggleMode('pixelate')"
           />
           <label class="game-options_optionLabel">Pixelate</label>
         </div>

--- a/src/renderer/mods/extenssr/post_processing_controller.ts
+++ b/src/renderer/mods/extenssr/post_processing_controller.ts
@@ -156,6 +156,7 @@ export default class PostProcessingController {
   }
   setHandler(handler: PostprocessHandler) {
     this.handler = handler
+    this.passShaderInfoAndUniforms()
   }
   assemblePasses() {
     const passes: ShaderPass[] = []


### PR DESCRIPTION
Added a couple of fixes:
- already saved settings will be retrieved automatically
- some settings are mutually exclusive (e.g. 'water mode' and 'pixelated' mode), allow for that

Some flakiness may remain, but I reckon this should handle 99% of cases?

The remaining thing is hooking into the StreetViewPanorama API, and calling `window.ppController.setupStreetView(streetview)`. This would allow the `motionBlur` effect to work (not that I think it'd be popular :D ), but also would help some flakiness with toggling `noCar` on/off in NMPZ.